### PR TITLE
Display 'svgfill' executable

### DIFF
--- a/to_md.py
+++ b/to_md.py
@@ -20,7 +20,7 @@ def _():
             if len(parts) == 4:
                 product, version, hash, os = parts
                 
-                if product in {'IfcConvert', 'IfcGeomServer'}:
+                if product in {'IfcConvert', 'IfcGeomServer', 'svgfill'}:
                     pass
                 elif re.match(r'^ifcopenshell-python-\d{2,3}u?$', product):
                     pass


### PR DESCRIPTION
Since we're uploading it either way - e.g. https://s3.amazonaws.com/ifcopenshell-builds/svgfill-v0.8.4-01ae64c-win64.zip